### PR TITLE
body: prevent shell interpolation of arguments

### DIFF
--- a/body
+++ b/body
@@ -2,14 +2,15 @@
 #
 # body: apply expression to all but the first line.
 # Use multiple times in case the header spans more than one line.
-# 
+#
 # Example usage:
 # $ seq 10 | header -a 'values' | body sort -nr
 # $ seq 10 | header -a 'multi\nline\nheader' | body body body sort -nr
+# $ printf "first_name\njim\nbob\nmary\n" | body ruby -nle 'puts $_.capitalize'
 #
-# From: http://unix.stackexchange.com/a/11859
+# From: https://unix.stackexchange.com/a/11859
 #
-# See also: header (https://github.com/jeroenjanssens/command-line-tools-for-data-science)
+# See also: header (https://github.com/jeroenjanssens/dsutils)
 IFS= read -r header
 printf '%s\n' "$header"
-eval $@
+"$@"


### PR DESCRIPTION
Allow arguments containing whitespace or characters special to the shell to be
passed through correctly, i.e. unchanged. Note that the originally cited Unix
Stack Exchange answer was updated by someone as well. Below is an example.

Before (using `eval $@`):

```bash
$ printf "first_name\njim\nbob\nmary\n" | body ruby -nle 'puts $_.capitalize'
first_name
Traceback (most recent call last):
        2: from -e:1:in `<main>'
        1: from -e:1:in `gets'
-e:1:in `gets': No such file or directory @ rb_sysopen - first_name.capitalize (Errno::ENOENT)
```

After (using `"$@"`):

```bash
$ printf "first_name\njim\nbob\nmary\n" | body ruby -nle 'puts $_.capitalize'
first_name
Jim
Bob
Mary
```